### PR TITLE
Add test for Encoding interface and corresponding patch

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -257,6 +257,7 @@ func (en *encoder) value(key uint64, val reflect.Value, prefix TagPrefix) {
 		}
 		if enc, ok := val.Interface().(Encoding); ok {
 			en.uvarint(key | 2)
+			en.uvarint(uint64(enc.Len()))
 			en.Write(enc.Encode())
 			return
 		}

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -1,0 +1,63 @@
+package protobuf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type Number interface {
+	Encoding
+
+	Value() int
+}
+
+type Int struct {
+	N int
+}
+
+type Wrapper struct {
+	N Number
+}
+
+func NewNumber(n int) Number {
+	return &Int{n}
+}
+
+func (i *Int) Value() int {
+	return i.N
+}
+
+func (i *Int) String() string {
+	return fmt.Sprintf("Int: %d", i.N)
+}
+
+func (i *Int) Len() int {
+	return 1
+}
+
+func (i *Int) Encode() []byte {
+	return []byte{byte(i.N)}
+}
+
+func (i *Int) Decode(data []byte) error {
+	i.N = int(data[0])
+	return nil
+}
+
+var _ Encoding = (*Int)(nil)
+
+// Validate that support for self-encoding via the Encoding
+// interface works as expected
+func TestEncoding(t *testing.T) {
+	wrapper := Wrapper{NewNumber(99)}
+	buf, err := Encode(&wrapper)
+	assert.Nil(t, err)
+
+	wrapper2 := Wrapper{NewNumber(0)}
+	err = Decode(buf, &wrapper2)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 99, wrapper2.N.Value())
+}


### PR DESCRIPTION
Special-case handling of the Encoding interface was missing the length-delimiter in the encoding.
