### PR TITLE
Support for golang map[] in fields

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -126,7 +126,7 @@ func (de *decoder) value(wiretype int, buf []byte,
 
 	case 5: // 32-bit
 		if len(buf) < 4 {
-			return nil, errors.New("bad protobuf 64-bit value")
+			return nil, errors.New("bad protobuf 32-bit value")
 		}
 		v = uint64(buf[0]) |
 			uint64(buf[1])<<8 |

--- a/decode.go
+++ b/decode.go
@@ -286,7 +286,7 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 			// make(map[k]v):
 			val.Set(reflect.MakeMap(val.Type()))
 		}
-		return de.handleMap(val, vb)
+		return de.mapEntry(val, vb)
 	case reflect.Interface:
 		// Abstract field: instantiate via dynamic constructor.
 		if val.IsNil() {
@@ -391,7 +391,8 @@ func (de *decoder) slice(slval reflect.Value, vb []byte) error {
 	return nil
 }
 
-func (de *decoder) handleMap(slval reflect.Value, vb []byte) error {
+// Handles the entry k,v of a map[K]V
+func (de *decoder) mapEntry(slval reflect.Value, vb []byte) error {
 	mKey := reflect.New(slval.Type().Key())
 	mVal := reflect.New(slval.Type().Elem())
 	k := mKey.Elem()
@@ -421,8 +422,8 @@ func (de *decoder) handleMap(slval reflect.Value, vb []byte) error {
 	}
 
 	if !k.IsValid() || !v.IsValid() {
-		// 	// We did not decode the key or the value in the map entry.
-		// 	// Either way, it's an invalid map entry.
+		// We did not decode the key or the value in the map entry.
+		// Either way, it's an invalid map entry.
 		return fmt.Errorf("proto: bad map data: missing key/val")
 	}
 	slval.SetMapIndex(k, v)

--- a/encode.go
+++ b/encode.go
@@ -359,7 +359,7 @@ func (en *encoder) slice(key uint64, slval reflect.Value) {
 func (en *encoder) map_(key uint64, mpval reflect.Value) {
 
 	//keycopy, valcopy, keybase, valbase := mapEncodeScratch(mpval.Type())
-	keycopy, valcopy, _, _ := mapEncodeScratch(mpval.Type())
+	//keycopy, valcopy, keybase, valbase := mapEncodeScratch(mpval.Type())
 
 	for _, mkey := range mpval.MapKeys() {
 		val := mpval.MapIndex(mkey)
@@ -368,23 +368,11 @@ func (en *encoder) map_(key uint64, mpval reflect.Value) {
 		if val.Kind() == reflect.Ptr && val.IsNil() {
 			panic("proto: map has nil element")
 		}
-
-		keycopy.Set(mkey)
-		valcopy.Set(val)
-		en.value(key, keycopy, TagNone)
-		en.value(key, valcopy, TagNone)
+		fmt.Printf("[key %v", mkey)
+		fmt.Printf(", val %v]\n", val)
+		en.value(key, mkey, TagNone)
+		en.value(key, val, TagNone)
 	}
-
-	// First handle common cases with a direct typeswitch
-	mplen := mpval.Len()
-	// packed := encoder{}
-	switch mpt := mpval.Interface().(type) {
-	default:
-		fmt.Printf("mpval.Interface().(type) = %v\n", mpt)
-		fmt.Printf("mplen := mpval.Len() = %v\n", mplen)
-	}
-
-	//panic(fmt.Sprintf("Hopefully soon supported Type (Map): %d", mpval.Kind()))
 }
 
 var bytesType = reflect.TypeOf([]byte{})

--- a/encode.go
+++ b/encode.go
@@ -355,6 +355,7 @@ func (en *encoder) slice(key uint64, slval reflect.Value) {
 	en.Write(b)
 }
 
+// Handle the encoding of an arbritary map[K]V
 func (en *encoder) handleMap(key uint64, mpval reflect.Value, prefix TagPrefix) {
 	/*
 		A map defined as

--- a/encode.go
+++ b/encode.go
@@ -84,6 +84,7 @@ var timeType = reflect.TypeOf(time.Time{})
 var durationType = reflect.TypeOf(time.Duration(0))
 
 func (en *encoder) value(key uint64, val reflect.Value, prefix TagPrefix) {
+
 	// Non-reflectively handle some of the fixed types
 	switch v := val.Interface().(type) {
 	case bool:
@@ -176,7 +177,6 @@ func (en *encoder) value(key uint64, val reflect.Value, prefix TagPrefix) {
 		return
 
 	}
-	//fmt.Printf("type %s\n", val.Type().Name())
 
 	// Handle pointer or interface values (possibly within slices).
 	// Note that this switch has to handle all the cases,
@@ -396,7 +396,6 @@ func (en *encoder) sliceReflect(key uint64, slval reflect.Value) {
 	sllen := slval.Len()
 	slelt := slval.Type().Elem()
 	packed := encoder{}
-
 	switch slelt.Kind() {
 	case reflect.Bool:
 		for i := 0; i < sllen; i++ {

--- a/encode.go
+++ b/encode.go
@@ -49,7 +49,11 @@ func Encode(structPtr interface{}) (bytes []byte, err error) {
 		return nil, nil
 	}
 	en := encoder{}
-	en.message(reflect.ValueOf(structPtr).Elem())
+	val := reflect.ValueOf(structPtr)
+	if val.Kind() != reflect.Ptr {
+		return nil, fmt.Errorf("Encode takes a pointer to struct")
+	}
+	en.message(val.Elem())
 	return en.Bytes(), nil
 }
 
@@ -80,7 +84,6 @@ var timeType = reflect.TypeOf(time.Time{})
 var durationType = reflect.TypeOf(time.Duration(0))
 
 func (en *encoder) value(key uint64, val reflect.Value, prefix TagPrefix) {
-
 	// Non-reflectively handle some of the fixed types
 	switch v := val.Interface().(type) {
 	case bool:

--- a/field_test.go
+++ b/field_test.go
@@ -39,10 +39,10 @@ func TestEncodeNested(t *testing.T) {
 		{11, TagNone, "renamed", []int{1, 2}, reflect.StructField{}},
 	}
 	assert.Equal(t, expected, actual)
-	assert.Equal(t, v.FieldByIndex(actual[0].Index).Int(), 13)
-	assert.Equal(t, v.FieldByIndex(actual[1].Index).Int(), 12)
-	assert.Equal(t, v.FieldByIndex(actual[2].Index).Int(), 14)
-	assert.Equal(t, v.FieldByIndex(actual[3].Index).Int(), 15)
+	assert.Equal(t, v.FieldByIndex(actual[0].Index).Int(), int64(13))
+	assert.Equal(t, v.FieldByIndex(actual[1].Index).Int(), int64(12))
+	assert.Equal(t, v.FieldByIndex(actual[2].Index).Int(), int64(14))
+	assert.Equal(t, v.FieldByIndex(actual[3].Index).Int(), int64(15))
 }
 
 type TestDuplicateID struct {

--- a/generate.go
+++ b/generate.go
@@ -121,7 +121,8 @@ func innerTypeName(t reflect.Type, enums enumTypeMap, renamer GeneratorNamer) st
 			}
 		} else if valType.Kind() == reflect.Ptr {
 			valTypeName = innerTypeName(valType.Elem(), enums, renamer)
-		} else { // here we can just use the value's type:
+		} else {
+			// here we can just use the value's type:
 			valTypeName = innerTypeName(valType, enums, renamer)
 		}
 		return fmt.Sprintf("map<%s, %s>", innerTypeName(t.Key(), enums, renamer), valTypeName)

--- a/generate_test.go
+++ b/generate_test.go
@@ -80,6 +80,28 @@ message PhoneNumber {
 	assert.Equal(t, expected, w.String())
 }
 
+func TestGenerateMapExample(t *testing.T) {
+	w := &bytes.Buffer{}
+	err := GenerateProtobufDefinition(w, []interface{}{MessageWithMap{}, FloatingPoint{}}, nil, nil)
+	assert.NoError(t, err)
+
+	expected := `
+message FloatingPoint {
+  optional double f = 1;
+}
+
+message MessageWithMap {
+  required map<uint32, string> name_mapping = 1;
+  required map<bool, bytes> byte_mapping = 2;
+  required map<sint64, FloatingPoint> msg_mapping = 3;
+  required map<string, string> str_to_str = 4;
+  required map<string, Inner> struct_mapping = 5;
+}
+
+`
+	assert.Equal(t, expected, w.String())
+}
+
 type TimeStruct struct {
 	Created time.Time
 	Delay   time.Duration

--- a/map_test.go
+++ b/map_test.go
@@ -14,7 +14,7 @@ type Inner struct {
 }
 
 type FloatingPoint struct {
-	F *float64 `protobuf:"fixed64,1,req,name=f" json:"f,omitempty"`
+	F *float64 `protobuf:"1,req"`
 }
 
 type MessageWithMap struct {

--- a/map_test.go
+++ b/map_test.go
@@ -17,7 +17,7 @@ type MessageWithMap struct {
 	//StructMapping map[string]Inner
 }
 
-func TestMapFieldMarshal(t *testing.T) {
+func TestMapFieldEncode(t *testing.T) {
 	m := &MessageWithMap{
 		NameMapping: map[int32]string{
 			1: "Rob",
@@ -25,9 +25,10 @@ func TestMapFieldMarshal(t *testing.T) {
 			8: "Dave",
 		},
 	}
+
 	b, err := Encode(m)
 	if err != nil {
-		t.Fatalf("Marshal: %v", err)
+		t.Fatalf("Encode: %v", err)
 	}
 
 	// b should be the concatenation of these three byte sequences in some order.
@@ -55,7 +56,7 @@ func TestMapFieldMarshal(t *testing.T) {
 		}
 	}
 	if !ok {
-		t.Fatalf("Incorrect Marshal output.\n got %q\nwant %q (or a permutation of that)", b, parts[0]+parts[1]+parts[2])
+		t.Fatalf("Incorrect Encoding output.\n got %q\nwant %q (or a permutation of that)", b, parts[0]+parts[1]+parts[2])
 	}
 	t.Logf("FYI b: %q", b)
 
@@ -83,6 +84,7 @@ func TestMapFieldRoundTrips(t *testing.T) {
 	}
 	t.Logf("FYI b: %q", b)
 	m2 := new(MessageWithMap)
+	// First fix the encoding:
 	if err := Decode(b, m2); err != nil {
 		t.Fatalf("Decode: %v", err)
 	}

--- a/map_test.go
+++ b/map_test.go
@@ -1,0 +1,108 @@
+package protobuf
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+type Inner struct {
+	Id   int32
+	Name string
+}
+
+type MessageWithMap struct {
+	NameMapping map[int32]string // = 1, required
+	//ByteMapping   map[bool][]byte
+	//StructMapping map[string]Inner
+}
+
+func TestMapFieldMarshal(t *testing.T) {
+	m := &MessageWithMap{
+		NameMapping: map[int32]string{
+			1: "Rob",
+			4: "Ian",
+			8: "Dave",
+		},
+	}
+	b, err := Encode(m)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	// b should be the concatenation of these three byte sequences in some order.
+	parts := []string{
+		"\n\a\b\x01\x12\x03Rob",
+		"\n\a\b\x04\x12\x03Ian",
+		"\n\b\b\x08\x12\x04Dave",
+	}
+	ok := false
+	for i := range parts {
+		for j := range parts {
+			if j == i {
+				continue
+			}
+			for k := range parts {
+				if k == i || k == j {
+					continue
+				}
+				try := parts[i] + parts[j] + parts[k]
+				if bytes.Equal(b, []byte(try)) {
+					ok = true
+					break
+				}
+			}
+		}
+	}
+	if !ok {
+		t.Fatalf("Incorrect Marshal output.\n got %q\nwant %q (or a permutation of that)", b, parts[0]+parts[1]+parts[2])
+	}
+	t.Logf("FYI b: %q", b)
+
+	//(new(Buffer)).DebugPrint("Dump of b", b)
+}
+
+func TestMapFieldRoundTrips(t *testing.T) {
+	m := &MessageWithMap{
+		NameMapping: map[int32]string{
+			1: "Rob",
+			4: "Ian",
+			8: "Dave",
+		},
+		// MsgMapping: map[int64]*FloatingPoint{
+		// 	0x7001: &FloatingPoint{F: Float64(2.0)},
+		// },
+		// ByteMapping: map[bool][]byte{
+		// 	false: []byte("that's not right!"),
+		// 	true:  []byte("aye, 'tis true!"),
+		// },
+	}
+	b, err := Encode(m)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	t.Logf("FYI b: %q", b)
+	m2 := new(MessageWithMap)
+	if err := Decode(b, m2); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	for _, pair := range [][2]interface{}{
+		{m.NameMapping, m2.NameMapping},
+	} {
+		if !reflect.DeepEqual(pair[0], pair[1]) {
+			t.Errorf("Map did not survive a round trip.\ninitial: %v\n  final: %v", pair[0], pair[1])
+		}
+	}
+}
+
+func TestMapFieldWithNil(t *testing.T) {
+	// m := &MessageWithMap{
+	// 	MsgMapping: map[int64]*FloatingPoint{
+	// 		1: nil,
+	// 	},
+	// }
+	// b, err := Marshal(m)
+	// if err == nil {
+	// 	t.Fatalf("Marshal of bad map should have failed, got these bytes: %v", b)
+	// }
+}

--- a/map_test.go
+++ b/map_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"reflect"
 	"testing"
-	// for more human friendly hex dump output (firs...last 3 bytes):
+	// for more human friendly hex dump output (first ... last 3 bytes):
 	// goprotobuf "github.com/golang/protobuf/proto"
 )
 
@@ -21,7 +21,8 @@ type MessageWithMap struct {
 	NameMapping   map[uint32]string // = 1, required
 	ByteMapping   map[bool][]byte
 	MsgMapping    map[int64]*FloatingPoint
-	StructMapping map[string]Inner
+	StrToStr      map[string]string
+	StructMapping map[string]*Inner
 }
 
 func TestMapFieldEncode(t *testing.T) {
@@ -37,7 +38,7 @@ func TestMapFieldEncode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Encode: %v", err)
 	}
-	//fmt.Print(hex.Dump(b))
+
 	// b should be the concatenation of these three byte sequences in some order.
 	parts := []string{
 		"\n\a\b\x01\x12\x03Rob",
@@ -85,9 +86,16 @@ func TestMapFieldRoundTrips(t *testing.T) {
 			false: []byte("that's not right!"),
 			true:  []byte("aye, 'tis true!"),
 		},
+		StrToStr: map[string]string{
+			"a key":     "value",
+			"other key": "other value",
+		},
+		StructMapping: map[string]*Inner{
+			"first":  &Inner{Id: 1, Name: "one"},
+			"second": &Inner{Id: 5, Name: "two"},
+		},
 	}
 	b, err := Encode(m)
-	// fmt.Print(hex.Dump(b))
 	if err != nil {
 		t.Fatalf("Encode: %v", err)
 	}
@@ -97,7 +105,6 @@ func TestMapFieldRoundTrips(t *testing.T) {
 	if err := Decode(b, m2); err != nil {
 		t.Fatalf("Decode: %v", err)
 	}
-	// fmt.Printf("m2=%v\n", m2)
 	for _, pair := range [][2]interface{}{
 		{m.NameMapping, m2.NameMapping},
 	} {

--- a/map_test.go
+++ b/map_test.go
@@ -95,6 +95,7 @@ func TestMapFieldRoundTrips(t *testing.T) {
 	if err := Decode(b, m2); err != nil {
 		t.Fatalf("Decode: %v", err)
 	}
+	fmt.Printf("m2=%v\n", m2)
 	for _, pair := range [][2]interface{}{
 		{m.NameMapping, m2.NameMapping},
 	} {

--- a/map_test.go
+++ b/map_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 	// for more human friendly hex dump output (firs...last 3 bytes):
-	goprotobuf "github.com/golang/protobuf/proto"
+	// goprotobuf "github.com/golang/protobuf/proto"
 )
 
 type Inner struct {
@@ -44,7 +44,7 @@ func TestMapFieldEncode(t *testing.T) {
 		"\n\a\b\x04\x12\x03Ian",
 		"\n\b\b\x08\x12\x04Dave",
 	}
-	// "\n\t\b\x01\x12\x05Linus\n\v\b\x04\x12\aNicolas\n\n\b\b\x12\x06Ismail"
+
 	ok := false
 	for i := range parts {
 		for j := range parts {
@@ -64,7 +64,6 @@ func TestMapFieldEncode(t *testing.T) {
 		}
 	}
 	if !ok {
-		(new(goprotobuf.Buffer)).DebugPrint("Dump of b", b)
 		t.Fatalf("Incorrect Encoding output.\n got %q\nwant %q (or a permutation of that)", b, parts[0]+parts[1]+parts[2])
 	}
 	t.Logf("FYI b: %q", b)
@@ -93,8 +92,8 @@ func TestMapFieldRoundTrips(t *testing.T) {
 		t.Fatalf("Encode: %v", err)
 	}
 	t.Logf("FYI b: %q", b)
+
 	m2 := new(MessageWithMap)
-	// First fix the encoding:
 	if err := Decode(b, m2); err != nil {
 		t.Fatalf("Decode: %v", err)
 	}


### PR DESCRIPTION
As we switched from using gob to protobuf in the cothority project, we also need to encode/decode maps (protobuf supports maps since [late 2014](https://github.com/golang/protobuf/commit/3ea3e05dbfae8d2dd0cc219b5f0f0ba4606d15eb)). Please review and merge when possible.
I also merged a small fix (see #11)  from @nikkolasg in this branch (other tests were failing without it).