### PR TITLE
Skip decoding invalid index

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -104,7 +104,11 @@ func (de *decoder) message(buf []byte, sval reflect.Value) error {
 		// Decode the field's value
 		rem, err := de.value(wiretype, buf, field)
 		if err != nil {
-			return fmt.Errorf("FieldName %s: %v", fields[fieldi].Name, err)
+			if fieldi < len(fields) {
+				return fmt.Errorf("FieldName %s: %v", fields[fieldi].Name, err)
+			} else {
+				return errors.New("Error while decoding: " + err.Error())
+			}
 		}
 		buf = rem
 	}

--- a/decode.go
+++ b/decode.go
@@ -8,6 +8,8 @@ import (
 	"math"
 	"reflect"
 	"time"
+
+	"github.com/dedis/cothority/lib/dbg"
 )
 
 // Constructors represents a map defining how to instantiate any interface
@@ -68,6 +70,7 @@ func DecodeWithConstructors(buf []byte, structPtr interface{}, cons Constructors
 // The Kind of the passed value v must be Struct.
 func (de *decoder) message(buf []byte, sval reflect.Value) error {
 	// Decode all the fields
+	dbg.Lvl5("Decoding", sval.Type())
 	fields := ProtoFields(sval.Type())
 	fieldi := 0
 	for len(buf) > 0 {
@@ -84,33 +87,33 @@ func (de *decoder) message(buf []byte, sval reflect.Value) error {
 		// Leave field with a zero Value if fieldnum is out-of-range.
 		// In this case, as well as for blank fields,
 		// value() will just skip over and discard the field content.
-		var field reflect.Value
 		for fieldi < len(fields) && fields[fieldi].ID < int64(fieldnum) {
 			fieldi++
 		}
-		// For fields within embedded structs, ensure the embedded values aren't nil.
-		if fieldi < len(fields) && fields[fieldi].ID == int64(fieldnum) {
-			index := fields[fieldi].Index
-			path := make([]int, 0, len(index))
-			for _, id := range index {
-				path = append(path, id)
-				field = sval.FieldByIndex(path)
-				if field.Kind() == reflect.Ptr && field.IsNil() {
-					field.Set(reflect.New(field.Type().Elem()))
+		// If we didn't skip everything, decode the value
+		if fieldi < len(fields) {
+			var field reflect.Value
+			// For fields within embedded structs, ensure the embedded values aren't nil.
+			if fields[fieldi].ID == int64(fieldnum) {
+				index := fields[fieldi].Index
+				path := make([]int, 0, len(index))
+				for _, id := range index {
+					path = append(path, id)
+					field = sval.FieldByIndex(path)
+					if field.Kind() == reflect.Ptr && field.IsNil() {
+						field.Set(reflect.New(field.Type().Elem()))
+					}
 				}
 			}
-		}
 
-		// Decode the field's value
-		rem, err := de.value(wiretype, buf, field)
-		if err != nil {
-			if fieldi < len(fields) {
-				return fmt.Errorf("FieldName %s: %v", fields[fieldi].Name, err)
-			} else {
-				return errors.New("Error while decoding: " + err.Error())
+			// Decode the field's value
+			rem, err := de.value(wiretype, buf, field)
+			if err != nil {
+				f := fields[fieldi].Field
+				return fmt.Errorf("FieldName #%d=%s/%s: %v", fieldi, f.Name, f.Type, err)
 			}
+			buf = rem
 		}
-		buf = rem
 	}
 	return nil
 }

--- a/decode.go
+++ b/decode.go
@@ -8,8 +8,6 @@ import (
 	"math"
 	"reflect"
 	"time"
-
-	"github.com/dedis/cothority/lib/dbg"
 )
 
 // Constructors represents a map defining how to instantiate any interface
@@ -70,7 +68,6 @@ func DecodeWithConstructors(buf []byte, structPtr interface{}, cons Constructors
 // The Kind of the passed value v must be Struct.
 func (de *decoder) message(buf []byte, sval reflect.Value) error {
 	// Decode all the fields
-	dbg.Lvl5("Decoding", sval.Type())
 	fields := ProtoFields(sval.Type())
 	fieldi := 0
 	for len(buf) > 0 {

--- a/encode.go
+++ b/encode.go
@@ -9,6 +9,8 @@ import (
 	"math"
 	"reflect"
 	"time"
+
+	"github.com/dedis/cothority/lib/dbg"
 )
 
 // Message fields declared to have exactly this type
@@ -59,6 +61,7 @@ func Encode(structPtr interface{}) (bytes []byte, err error) {
 
 func (en *encoder) message(sval reflect.Value) {
 	var index *ProtoField
+	dbg.Lvl5("Starting for", sval)
 	defer func() {
 		if r := recover(); r != nil {
 			if index != nil {
@@ -69,14 +72,18 @@ func (en *encoder) message(sval reflect.Value) {
 		}
 	}()
 	// Encode all fields in-order
-	for _, index = range ProtoFields(sval.Type()) {
+	var i int
+	for i, index = range ProtoFields(sval.Type()) {
 		field := sval.FieldByIndex(index.Index)
 		key := uint64(index.ID) << 3
+		s := sval.Type().Field(i)
+		dbg.Lvl5("Encoding", sval.Type(), s.Name, s.Type, field.Type())
 		//fmt.Printf("field %d: %s %v\n", 1+i,
 		//		sval.Type().Field(i).Name, field.CanSet())
 		if field.CanSet() { // Skip blank/padding fields
 			en.value(key, field, index.Prefix)
 		}
+		dbg.Lvl5("Done encoding", sval.Type(), s.Name, s.Type, field.Type())
 	}
 }
 

--- a/encode.go
+++ b/encode.go
@@ -69,16 +69,14 @@ func (en *encoder) message(sval reflect.Value) {
 		}
 	}()
 	// Encode all fields in-order
-	var i int
-	for i, index = range ProtoFields(sval.Type()) {
+	for _, index = range ProtoFields(sval.Type()) {
 		field := sval.FieldByIndex(index.Index)
 		key := uint64(index.ID) << 3
-		//s := sval.Type().Field(i)
-		//fmt.Print("Encoding", sval.Type(), s.Name, s.Type, field.Type())
+		//fmt.Print("Encoding", sval.Type(), index.Name, index.Type, field.Type())
 		if field.CanSet() { // Skip blank/padding fields
 			en.value(key, field, index.Prefix)
 		}
-		//fmt.Print("Done encoding", sval.Type(), s.Name, s.Type, field.Type())
+		//fmt.Print("Done encoding", sval.Type(), index.Name, index.Type, field.Type())
 	}
 }
 

--- a/encode.go
+++ b/encode.go
@@ -9,8 +9,6 @@ import (
 	"math"
 	"reflect"
 	"time"
-
-	"github.com/dedis/cothority/lib/dbg"
 )
 
 // Message fields declared to have exactly this type
@@ -61,7 +59,6 @@ func Encode(structPtr interface{}) (bytes []byte, err error) {
 
 func (en *encoder) message(sval reflect.Value) {
 	var index *ProtoField
-	dbg.Lvl5("Starting for", sval)
 	defer func() {
 		if r := recover(); r != nil {
 			if index != nil {
@@ -76,14 +73,12 @@ func (en *encoder) message(sval reflect.Value) {
 	for i, index = range ProtoFields(sval.Type()) {
 		field := sval.FieldByIndex(index.Index)
 		key := uint64(index.ID) << 3
-		s := sval.Type().Field(i)
-		dbg.Lvl5("Encoding", sval.Type(), s.Name, s.Type, field.Type())
-		//fmt.Printf("field %d: %s %v\n", 1+i,
-		//		sval.Type().Field(i).Name, field.CanSet())
+		//s := sval.Type().Field(i)
+		//fmt.Print("Encoding", sval.Type(), s.Name, s.Type, field.Type())
 		if field.CanSet() { // Skip blank/padding fields
 			en.value(key, field, index.Prefix)
 		}
-		dbg.Lvl5("Done encoding", sval.Type(), s.Name, s.Type, field.Type())
+		//fmt.Print("Done encoding", sval.Type(), s.Name, s.Type, field.Type())
 	}
 }
 

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -2,8 +2,9 @@ package protobuf
 
 import (
 	"encoding"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type Number interface {

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
 	//"encoding/hex"
 )
 


### PR DESCRIPTION
When the decoding-routine skips the last index, it shouldn't try to decode it but rather go on.