### PR TITLE
`map[][]struct` can't be encoded/decoded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+
+language: go
+
+notifications:
+  # Email notifications are disabled to not annoy anybody.
+  # See http://about.travis-ci.org/docs/user/build-configuration/ to learn more
+  # about configuring notification recipients and more.
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: go
 
 notifications:

--- a/decode.go
+++ b/decode.go
@@ -422,7 +422,7 @@ func (de *decoder) mapEntry(slval reflect.Value, vb []byte) error {
 	if err != nil {
 		return err
 	}
-	for len(buf) > 0 {
+	for len(buf) > 0 { // for repeated values (slices etc)
 		key, n = binary.Uvarint(buf)
 		if n <= 0 {
 			return errors.New("bad protobuf field key")

--- a/decode.go
+++ b/decode.go
@@ -422,16 +422,17 @@ func (de *decoder) mapEntry(slval reflect.Value, vb []byte) error {
 	if err != nil {
 		return err
 	}
-
-	key, n = binary.Uvarint(buf)
-	if n <= 0 {
-		return errors.New("bad protobuf field key")
-	}
-	buf = buf[n:]
-	wiretype = int(key & 7)
-	buf, err = de.value(wiretype, buf, v)
-	if err != nil {
-		return err
+	for len(buf) > 0 {
+		key, n = binary.Uvarint(buf)
+		if n <= 0 {
+			return errors.New("bad protobuf field key")
+		}
+		buf = buf[n:]
+		wiretype = int(key & 7)
+		buf, err = de.value(wiretype, buf, v)
+		if err != nil {
+			return err
+		}
 	}
 
 	if !k.IsValid() || !v.IsValid() {

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -2,8 +2,9 @@ package protobuf
 
 import (
 	"encoding"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type Number interface {

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	//"encoding/hex"
-	"encoding/hex"
 )
 
 type emb struct {
@@ -218,39 +217,29 @@ func TestTimeTypesEncodeDecode(t *testing.T) {
 	assert.Equal(t, in.Duration, out.Duration)
 }
 
-type CipherText struct {
-	A, B int32
+type cipherText struct {
+	A, B *int32
 }
 
 type testMsg struct {
-	M map[uint32]*CipherArr
-}
-
-type CipherArr struct {
-	V []*CipherText
+	M map[uint32][]cipherText
 }
 
 func TestMapSliceStruct(t *testing.T) {
-	ct := []*CipherText{{},{}}
-	ca := &CipherArr{V: ct}
-
+	cv := []cipherText{{}, {}}
 	msg := &testMsg{
-		M: map[uint32]*CipherArr{1: ca},
+		M: map[uint32][]cipherText{1: cv},
 	}
-	buf, err := Encode(msg)
-	fmt.Println(hex.Dump(buf))
-	// optional
-	// 0a 08 08 01 12 04 0a 00  0a 00
-	// 0a 08 08 01 12 04 0a 00  0a 00
-	// required
-	// 00000000  0a 10 08 01 12 0c 0a 04  08 00 10 00 0a 04 08 00  |................|
-	// 00000010  10 00                                             |..|
-	// 00000000  0a 10 08 01 12 0c 0a 04  08 00 10 00 0a 04 08 00  |................|
-	// 00000010  10 00                                             |..|
 
+	buf, err := Encode(msg)
+	//fmt.Println(hex.Dump(buf))
 	assert.NoError(t, err)
+
 	msg2 := &testMsg{}
 	err = Decode(buf, msg2)
 	assert.NoError(t, err)
-	assert.Equal(t, len(msg.M[1].V), len(msg2.M[1].V))
+	//fmt.Printf("FYI:\n%#v\n", msg2)
+	//fmt.Printf("%#v\n", msg2)
+
+	assert.Equal(t, len(msg.M[1]), len(msg2.M[1]))
 }

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -217,32 +217,33 @@ func TestTimeTypesEncodeDecode(t *testing.T) {
 	assert.Equal(t, in.Duration, out.Duration)
 }
 
+// encoding of testMsg is equivalent to the encoding to the following in
+// a .proto file:
+/*
+message cipherText {
+  optional int32 a = 1;
+    optional int32 b = 2;
+}
+
+message MapFieldEntry {
+  required uint32 key = 1;
+  repeated cipherText value = 2;
+}
+
+message testMsg {
+ repeated MapFieldEntry map_field = 1;
+}
+*/
+// for details see:
+// https://developers.google.com/protocol-buffers/docs/proto#backwards-compatibility
+type testMsg struct {
+	M map[uint32][]cipherText
+}
 type cipherText struct {
 	A, B *int32
 }
 
-type testMsg struct {
-	M map[uint32][]cipherText
-}
-
 func TestMapSliceStruct(t *testing.T) {
-	// equivalent to the encoding to the following in a .proto file:
-	// details: https://developers.google.com/protocol-buffers/docs/proto#backwards-compatibility
-	/*
-	message cipherText {
-	  optional int32 a = 1;
-  	  optional int32 b = 2;
-	}
-
-	message MapFieldEntry {
-	  required uint32 key = 1;
-	  repeated cipherText value = 2;
-	}
-
-	message testMsg {
-	 repeated MapFieldEntry map_field = 1;
-	}
-	*/
 	cv := []cipherText{{}, {}}
 	msg := &testMsg{
 		M: map[uint32][]cipherText{1: cv},

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -227,6 +227,7 @@ type testMsg struct {
 
 func TestMapSliceStruct(t *testing.T) {
 	// equivalent to the encoding to the following in a .proto file:
+	// details: https://developers.google.com/protocol-buffers/docs/proto#backwards-compatibility
 	/*
 	message cipherText {
 	  optional int32 a = 1;
@@ -242,7 +243,6 @@ func TestMapSliceStruct(t *testing.T) {
 	 repeated MapFieldEntry map_field = 1;
 	}
 	*/
-	// see: https://developers.google.com/protocol-buffers/docs/proto#backwards-compatibility
 	cv := []cipherText{{}, {}}
 	msg := &testMsg{
 		M: map[uint32][]cipherText{1: cv},

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	//"encoding/hex"
+	"encoding/hex"
 )
 
 type emb struct {
@@ -218,7 +219,7 @@ func TestTimeTypesEncodeDecode(t *testing.T) {
 }
 
 type CipherText struct {
-	A, B *int32
+	A, B int32
 }
 
 type testMsg struct {
@@ -237,7 +238,16 @@ func TestMapSliceStruct(t *testing.T) {
 		M: map[uint32]*CipherArr{1: ca},
 	}
 	buf, err := Encode(msg)
-	//fmt.Println(hex.Dump(buf))
+	fmt.Println(hex.Dump(buf))
+	// optional
+	// 0a 08 08 01 12 04 0a 00  0a 00
+	// 0a 08 08 01 12 04 0a 00  0a 00
+	// required
+	// 00000000  0a 10 08 01 12 0c 0a 04  08 00 10 00 0a 04 08 00  |................|
+	// 00000010  10 00                                             |..|
+	// 00000000  0a 10 08 01 12 0c 0a 04  08 00 10 00 0a 04 08 00  |................|
+	// 00000010  10 00                                             |..|
+
 	assert.NoError(t, err)
 	msg2 := &testMsg{}
 	err = Decode(buf, msg2)

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -218,21 +218,29 @@ func TestTimeTypesEncodeDecode(t *testing.T) {
 }
 
 type CipherText struct {
-	A, B int
+	A, B *int32
 }
+
 type testMsg struct {
-	M map[uint32][]CipherText
+	M map[uint32]*CipherArr
+}
+
+type CipherArr struct {
+	V []*CipherText
 }
 
 func TestMapSliceStruct(t *testing.T) {
-	cv := []CipherText{{}, {}}
+	ct := []*CipherText{{},{}}
+	ca := &CipherArr{V: ct}
+
 	msg := &testMsg{
-		M: map[uint32][]CipherText{1: cv},
+		M: map[uint32]*CipherArr{1: ca},
 	}
 	buf, err := Encode(msg)
+	//fmt.Println(hex.Dump(buf))
 	assert.NoError(t, err)
 	msg2 := &testMsg{}
 	err = Decode(buf, msg2)
 	assert.NoError(t, err)
-	assert.Equal(t, len(msg.M[1]), len(msg2.M[1]))
+	assert.Equal(t, len(msg.M[1].V), len(msg2.M[1].V))
 }

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
 	//"encoding/hex"
 )
 
@@ -216,4 +215,24 @@ func TestTimeTypesEncodeDecode(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, in.Time.UnixNano(), out.Time.UnixNano())
 	assert.Equal(t, in.Duration, out.Duration)
+}
+
+type CipherText struct {
+	A, B int
+}
+type testMsg struct {
+	M map[uint32][]CipherText
+}
+
+func TestMapSliceStruct(t *testing.T) {
+	cv := []CipherText{{}, {}}
+	msg := &testMsg{
+		M: map[uint32][]CipherText{1: cv},
+	}
+	buf, err := Encode(msg)
+	assert.NoError(t, err)
+	msg2 := &testMsg{}
+	err = Decode(buf, msg2)
+	assert.NoError(t, err)
+	assert.Equal(t, len(msg.M[1]), len(msg2.M[1]))
 }

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -226,6 +226,23 @@ type testMsg struct {
 }
 
 func TestMapSliceStruct(t *testing.T) {
+	// equivalent to the encoding to the following in a .proto file:
+	/*
+	message cipherText {
+	  optional int32 a = 1;
+  	  optional int32 b = 2;
+	}
+
+	message MapFieldEntry {
+	  required uint32 key = 1;
+	  repeated cipherText value = 2;
+	}
+
+	message testMsg {
+	 repeated MapFieldEntry map_field = 1;
+	}
+	*/
+	// see: https://developers.google.com/protocol-buffers/docs/proto#backwards-compatibility
 	cv := []cipherText{{}, {}}
 	msg := &testMsg{
 		M: map[uint32][]cipherText{1: cv},


### PR DESCRIPTION
When working on maps of slices of structs, decoding fails. I presume it's decoding, as the encoding seems to take everything correctly.