### PR TITLE
fix interface type decoded as empty value by recursive approach

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -308,7 +308,7 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 		// Decode into the object the interface points to.
 		// XXX perhaps better ONLY to support self-decoding
 		// for interface fields?
-		return de.putvalue(wiretype, val.Elem(), v, vb)
+		return Decode(vb, val.Interface())
 
 	default:
 		panic("unsupported value kind " + val.Kind().String())

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -56,3 +56,35 @@ func TestBinaryMarshaler(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 99, wrapper2.N.Value())
 }
+
+type NumberNoMarshal interface {
+	Value() int
+}
+
+func NewNumberNoMarshal(n int) NumberNoMarshal {
+	return &IntNoMarshal{n}
+}
+
+type IntNoMarshal struct {
+	N int
+}
+
+func (i *IntNoMarshal) Value() int {
+	return i.N
+}
+
+type WrapperNoMarshal struct {
+	N NumberNoMarshal
+}
+
+func TestNoBinaryMarshaler(t *testing.T) {
+	wrapper := WrapperNoMarshal{NewNumberNoMarshal(99)}
+	buf, err := Encode(&wrapper)
+	assert.Nil(t, err)
+
+	wrapper2 := WrapperNoMarshal{NewNumberNoMarshal(0)}
+	err = Decode(buf, &wrapper2)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 99, wrapper2.N.Value())
+}


### PR DESCRIPTION
Found that field with interface type is decoded without value if it does not support "UnmarshalBinary".
I am not very sure about how "putvalue" works but recursively calling "Decode" solved the problem