### PR TITLE
Multi dimensional slices

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -3,7 +3,6 @@ package protobuf
 import (
 	"testing"
 
-	"github.com/dedis/cothority/log"
 	"github.com/dedis/crypto/abstract"
 	"github.com/dedis/crypto/ed25519"
 )
@@ -35,18 +34,21 @@ func BenchmarkEncode(b *testing.B) {
 		}
 
 	}
-	log.Lvl1("Done setting up")
 	Msg := &Message{}
 	var err error
 	Msg.Bytes, err = Encode(big)
-	log.ErrFatal(err)
+	if err != nil {
+		b.Fatal(err)
+	}
 	if len(Msg.Bytes) < x*y {
 		b.Fatal("Not enough data")
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		bytes, err := Encode(Msg)
-		log.ErrFatal(err)
+		if err != nil {
+			b.Fatal(err)
+		}
 		if len(bytes) < x*y {
 			b.Fatal("Message not long enough")
 		}

--- a/encode.go
+++ b/encode.go
@@ -441,6 +441,9 @@ func (en *encoder) sliceReflect(key uint64, slval reflect.Value) {
 		en.Write(b)
 		return
 
+	case reflect.Slice, reflect.Array:
+		panic("protobuf: no support for multi-dimensional array")
+
 	default: // Write each element as a separate key,value pair
 		for i := 0; i < sllen; i++ {
 			en.value(key, slval.Index(i), TagNone)

--- a/generate_test.go
+++ b/generate_test.go
@@ -51,9 +51,8 @@ message test {
   repeated ufixed64 sux64 = 108 [packed=true];
   repeated float sf32 = 109 [packed=true];
   repeated double sf64 = 110 [packed=true];
-  repeated bytes sbytes = 111;
-  repeated string sstring = 112;
-  repeated emb sstruct = 113;
+  repeated string sstring = 111;
+  repeated emb sstruct = 112;
 }
 
 `

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -67,7 +67,6 @@ type test struct {
 	SUX64   []Ufixed64
 	SF32    []myfloat32
 	SF64    []myfloat64
-	SBytes  []mybytes
 	SString []mystring
 	SStruct []emb
 }
@@ -126,7 +125,6 @@ func (t1 *test) equal(t2 *test) bool {
 		eqrep(t1.SUX64, t2.SUX64) &&
 		eqrep(t1.SF32, t2.SF32) &&
 		eqrep(t1.SF64, t2.SF64) &&
-		eqrep(t1.SBytes, t2.SBytes) &&
 		eqrep(t1.SString, t2.SString) &&
 		eqrep(t1.SStruct, t2.SStruct)
 }
@@ -153,7 +151,6 @@ func TestProtobuf(t *testing.T) {
 		[]Sfixed32{11, -22, 33}, []Sfixed64{22, -33, 44},
 		[]Ufixed32{33, 44, 55}, []Ufixed64{44, 55, 66},
 		[]myfloat32{5.5, 6.6, 7.7}, []myfloat64{6.6, 7.7, 8.8},
-		[]mybytes{[]byte("abc"), []byte("def")},
 		[]mystring{"the", "quick", "brown", "fox"},
 		[]emb{emb{-1, "a"}, emb{-2, "b"}, emb{-3, "c"}},
 	}


### PR DESCRIPTION
This PR make protobuf return an error when trying to encode a `[][]whatever`. It fixes #19 .
Question: Should we return an error too in the decoding part ?