### PR TITLE
Slice of Slices & Slice in values

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -389,7 +389,7 @@ func (en *encoder) handleMap(key uint64, mpval reflect.Value, prefix TagPrefix) 
 				panic("proto: map has nil element")
 			}
 		case reflect.Slice, reflect.Array:
-			if mval.Elem().Type().Kind() != reflect.Uint8 {
+			if mval.Type().Elem().Kind() != reflect.Uint8 {
 				panic("protobuf: map only support []byte or string as repeated value")
 			}
 		}

--- a/encode.go
+++ b/encode.go
@@ -343,6 +343,16 @@ func (en *encoder) slice(key uint64, slval reflect.Value) {
 		en.Write(slt)
 		return
 
+	case []string:
+		for i := 0; i < sllen; i++ {
+			subVal := slval.Index(i)
+			subStr := subVal.Interface().(string)
+			subSlice := []byte(subStr)
+			en.uvarint(key | 2)
+			en.uvarint(uint64(len(subSlice)))
+			en.Write(subSlice)
+		}
+
 	default: // We'll need to use the reflective path
 		en.sliceReflect(key, slval)
 		return
@@ -441,10 +451,15 @@ func (en *encoder) sliceReflect(key uint64, slval reflect.Value) {
 		en.Write(b)
 		return
 
-	case reflect.Slice, reflect.Array:
-		panic("protobuf: no support for multi-dimensional array")
-
 	default: // Write each element as a separate key,value pair
+		t := slval.Type().Elem()
+		if t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
+			subSlice := t.Elem()
+			if subSlice.Kind() != reflect.Uint8 {
+				panic("protobuf: no support for 2-dimensional array except for [][]byte")
+			}
+		}
+
 		for i := 0; i < sllen; i++ {
 			en.value(key, slval.Index(i), TagNone)
 		}

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -88,3 +88,22 @@ func TestNoBinaryMarshaler(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 99, wrapper2.N.Value())
 }
+
+type WrongSliceInt struct {
+	Ints [][]int
+}
+type WrongSliceUint struct {
+	UInts [][]uint16
+}
+
+func TestNo2dSlice(t *testing.T) {
+	w := &WrongSliceInt{}
+	w.Ints = [][]int{[]int{1, 2, 3}, []int{4, 5, 6}}
+	_, err := Encode(w)
+	assert.NotNil(t, err)
+
+	w2 := &WrongSliceUint{}
+	w2.UInts = [][]uint16{[]uint16{1, 2, 3}, []uint16{4, 5, 6}}
+	_, err = Encode(w2)
+	assert.NotNil(t, err)
+}

--- a/generate_test.go
+++ b/generate_test.go
@@ -51,8 +51,9 @@ message test {
   repeated ufixed64 sux64 = 108 [packed=true];
   repeated float sf32 = 109 [packed=true];
   repeated double sf64 = 110 [packed=true];
-  repeated string sstring = 111;
-  repeated emb sstruct = 112;
+  repeated bytes sbytes = 111;
+  repeated string sstring = 112;
+  repeated emb sstruct = 113;
 }
 
 `

--- a/map_test.go
+++ b/map_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 	// for more human friendly hex dump output (first ... last 3 bytes):
 	// goprotobuf "github.com/golang/protobuf/proto"
 )
@@ -124,4 +126,18 @@ func TestMapFieldWithNil(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Marshal of bad map should have failed, got these bytes: %v", b)
 	}
+}
+
+type WrongMap struct {
+	Map map[string][]uint32
+}
+
+func TestMapWrongSliceValue(t *testing.T) {
+	w := &WrongMap{}
+	w.Map = make(map[string][]uint32)
+	w.Map["hello"] = []uint32{1, 2, 3}
+	w.Map["world"] = []uint32{4, 5, 6}
+
+	_, err := Encode(w)
+	assert.NotNil(t, err)
 }

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -67,6 +67,7 @@ type test struct {
 	SUX64   []Ufixed64
 	SF32    []myfloat32
 	SF64    []myfloat64
+	SBytes  []mybytes
 	SString []mystring
 	SStruct []emb
 }
@@ -125,6 +126,7 @@ func (t1 *test) equal(t2 *test) bool {
 		eqrep(t1.SUX64, t2.SUX64) &&
 		eqrep(t1.SF32, t2.SF32) &&
 		eqrep(t1.SF64, t2.SF64) &&
+		eqrep(t1.SBytes, t2.SBytes) &&
 		eqrep(t1.SString, t2.SString) &&
 		eqrep(t1.SStruct, t2.SStruct)
 }
@@ -151,6 +153,7 @@ func TestProtobuf(t *testing.T) {
 		[]Sfixed32{11, -22, 33}, []Sfixed64{22, -33, 44},
 		[]Ufixed32{33, 44, 55}, []Ufixed64{44, 55, 66},
 		[]myfloat32{5.5, 6.6, 7.7}, []myfloat64{6.6, 7.7, 8.8},
+		[]mybytes{[]byte("the"), []byte("quick"), []byte("brown"), []byte("fox")},
 		[]mystring{"the", "quick", "brown", "fox"},
 		[]emb{emb{-1, "a"}, emb{-2, "b"}, emb{-3, "c"}},
 	}

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -218,25 +218,23 @@ func TestTimeTypesEncodeDecode(t *testing.T) {
 	assert.Equal(t, in.Duration, out.Duration)
 }
 
-// encoding of testMsg is equivalent to the encoding to the following in
-// a .proto file:
-/*
-message cipherText {
-  optional int32 a = 1;
-    optional int32 b = 2;
-}
+/*encoding of testMsg is equivalent to the encoding to the following in*/
+//a .proto file:
+//	  message cipherText {
+//	  int32 a = 1;
+//	  int32 b = 2;
+//	  }
 
-message MapFieldEntry {
-  required uint32 key = 1;
-  repeated cipherText value = 2;
-}
+//	  message MapFieldEntry {
+//	  uint32 key = 1;
+//	  cipherText value = 2;
+//	  }
 
-message testMsg {
- repeated MapFieldEntry map_field = 1;
-}
-*/
-// for details see:
-// https://developers.google.com/protocol-buffers/docs/proto#backwards-compatibility
+//	  message testMsg {
+//	  repeated MapFieldEntry map_field = 1;
+//	  }
+//for details see:
+/*https://developers.google.com/protocol-buffers/docs/proto#backwards-compatibility*/
 type wrongTestMsg struct {
 	M map[uint32][]cipherText
 }


### PR DESCRIPTION
This PR is a correction to https://github.com/dedis/protobuf/pull/31.
It forbids to use a `[][]TYPE` when `TYPE != byte` as a field.
It forbids to use a `[]TYPE` for keys. One can still use `string` or `[]byte` because it's equivalent to `bytes` in protobuf types.
It forbids to use a `[]TYPE` or `map[Key]Value` in the *value* of a map.