### PR TITLE
[Slice] encoding of []string allowed

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -175,7 +175,6 @@ func (en *encoder) value(key uint64, val reflect.Value, prefix TagPrefix) {
 		en.uvarint(uint64(len(v)))
 		en.Write(v)
 		return
-
 	}
 
 	// Handle pointer or interface values (possibly within slices).
@@ -343,6 +342,16 @@ func (en *encoder) slice(key uint64, slval reflect.Value) {
 		en.Write(slt)
 		return
 
+	case []string:
+		for i := 0; i < sllen; i++ {
+			subVal := slval.Index(i)
+			subStr := subVal.Interface().(string)
+			subSlice := []byte(subStr)
+			en.uvarint(key | 2)
+			en.uvarint(uint64(len(subSlice)))
+			en.Write(subSlice)
+		}
+		return
 	default: // We'll need to use the reflective path
 		en.sliceReflect(key, slval)
 		return


### PR DESCRIPTION
This PR allows a correct encoding of a slice of string. This is "urgently" needed by the medco people, so I did not bother doing an issue.