### PR TITLE
Set the capacity of decoded byte slices

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -161,7 +161,7 @@ func (de *decoder) value(wiretype int, buf []byte,
 			return nil, errors.New(
 				"bad protobuf length-delimited value")
 		}
-		vb = buf[n : n+int(v)]
+		vb = buf[n : n+int(v) : n+int(v)]
 		buf = buf[n+int(v):]
 
 	default:


### PR DESCRIPTION
If two byte slices are next to each other in the struct, upon decoding
the first byte slice will have a cap that overflows onto the second
slice. If the first byte slice is then stretched with append such that
it ends up smaller than the cap of the first slice, the second slice
will be overwritten.

The fix is that on Decode, we must always return slices with cap ==
len, so that if the caller wants to extend the slice, he/she will be
obliged to copy it.

Fixes #40.