### PR TITLE
Add support for []int on the decoding part

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -3,9 +3,9 @@ package protobuf
 import (
 	"fmt"
 	"testing"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"encoding/hex"
+	"github.com/stretchr/testify/require"
 )
 
 type ArrayTest0 struct {
@@ -65,5 +65,8 @@ func TestArray(t *testing.T){
 	Decode(buf3, &b3)
 	t.Log(b3, reflect.TypeOf(b3))
 
-	assert.True(t, true, nil)
+	require.Equal(t, a0, b0)
+	require.Equal(t, a1, b1)
+	require.Equal(t, a2, b2)
+	require.Equal(t, a3, b3)
 }

--- a/array_test.go
+++ b/array_test.go
@@ -1,0 +1,69 @@
+package protobuf
+
+import (
+	"fmt"
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"encoding/hex"
+)
+
+type ArrayTest0 struct {
+	A []int
+}
+
+type ArrayTest1 struct {
+	A []int64
+}
+
+type ArrayTest2 struct {
+	A []int32
+}
+
+type ArrayTest3 struct{
+	A int
+}
+
+
+func TestArray(t *testing.T){
+
+	fmt.Println("TestArray:")
+
+	// largest int32 is 2147483647
+	var large int = 3147483647
+
+	a0 := ArrayTest0{[]int{1, 1, large}}
+	a1 := ArrayTest1{[]int64{1, 1, 1}}
+	a2 := ArrayTest2{[]int32{1, 1, 1}}
+	a3 := ArrayTest3{1}
+
+	buf0, _ := Encode(&a0)
+	buf1, _ := Encode(&a1)
+	buf2, _ := Encode(&a2)
+	buf3, _ := Encode(&a3)
+
+	t.Log(hex.Dump(buf0))
+	t.Log(hex.Dump(buf1))
+	t.Log(hex.Dump(buf2))
+	t.Log(hex.Dump(buf3))
+
+
+	b0 := ArrayTest0{}
+	b1 := ArrayTest1{}
+	b2 := ArrayTest2{}
+	b3 := ArrayTest3{}
+
+	Decode(buf0, &b0)
+	t.Log(b0, reflect.TypeOf(b0))
+
+	Decode(buf1, &b1)
+	t.Log(b1, reflect.TypeOf(b1))
+
+	Decode(buf2, &b2)
+	t.Log(b2, reflect.TypeOf(b2))
+
+	Decode(buf3, &b3)
+	t.Log(b3, reflect.TypeOf(b3))
+
+	assert.True(t, true, nil)
+}

--- a/decode.go
+++ b/decode.go
@@ -215,7 +215,7 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 	// Note that protobufs don't support 8- or 16-bit ints.
 	case reflect.Int, reflect.Int32, reflect.Int64:
 		if val.Kind() == reflect.Int && val.Type().Size() < 8 {
-			return errors.New("detected a 32bit machine, please either use int64 or int32")
+			return errors.New("detected a 32bit machine, please use either int64 or int32")
 		}
 		sv, err := de.decodeSignedInt(wiretype, v)
 		if err != nil {
@@ -227,7 +227,7 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 	// Varint-encoded 32-bit and 64-bit unsigned integers.
 	case reflect.Uint, reflect.Uint32, reflect.Uint64:
 		if val.Kind() == reflect.Uint && val.Type().Size() < 8 {
-			return errors.New("detected a 32bit machine, please either use uint64 or uint32")
+			return errors.New("detected a 32bit machine, please use either uint64 or uint32")
 		}
 		if wiretype == 0 {
 			val.SetUint(v)
@@ -361,8 +361,7 @@ func (de *decoder) slice(slval reflect.Value, vb []byte) error {
 	case reflect.Bool, reflect.Int32, reflect.Int64, reflect.Int,
 		reflect.Uint32, reflect.Uint64, reflect.Uint:
 		if (eltype.Kind() == reflect.Int || eltype.Kind() == reflect.Uint) && eltype.Size() < 8 {
-			panic("Detected a 32bit machine, please either use (u)int64 or (u)int32. " +
-				"However, ensure you are using the same size being used on the sender side not to lose information.")
+			return errors.New("detected a 32bit machine, please either use (u)int64 or (u)int32")
 		}
 		switch eltype {
 

--- a/decode.go
+++ b/decode.go
@@ -215,8 +215,7 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 	// Note that protobufs don't support 8- or 16-bit ints.
 	case reflect.Int, reflect.Int32, reflect.Int64:
 		if val.Kind() == reflect.Int && val.Type().Size() < 8 {
-			panic("Detected a 32bit machine, please either use int64 or int32. " +
-				"However, ensure you are using the same size being used on the sender side not to lose information.")
+			return errors.New("detected a 32bit machine, please either use int64 or int32")
 		}
 		sv, err := de.decodeSignedInt(wiretype, v)
 		if err != nil {
@@ -228,8 +227,7 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 	// Varint-encoded 32-bit and 64-bit unsigned integers.
 	case reflect.Uint, reflect.Uint32, reflect.Uint64:
 		if val.Kind() == reflect.Uint && val.Type().Size() < 8 {
-			panic("Detected a 32bit machine, please either use uint64 or uint32. " +
-				"However, ensure you are using the same size being used on the sender side not to lose information.")
+			return errors.New("detected a 32bit machine, please either use uint64 or uint32")
 		}
 		if wiretype == 0 {
 			val.SetUint(v)


### PR DESCRIPTION
Add case reflect.Int and reflect.Uint in decode.go for both slice and putvalue. Also add a check to see if the machine is 32bit, if it is, we panic, forcing the user to decode either (u)int32 or (u)int64.
Add test `array_test.go`.

Closes #14 