### PR TITLE
No serializable fields

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -79,7 +79,7 @@ func (en *encoder) message(sval reflect.Value) {
 		}
 	}
 	if noPublicFields {
-		panic("struct has no serializable fields")
+		fmt.Println("struct has no serializable fields")
 	}
 }
 

--- a/encode.go
+++ b/encode.go
@@ -54,11 +54,6 @@ func Encode(structPtr interface{}) (bytes []byte, err error) {
 		return nil, errors.New("encode takes a pointer to struct")
 	}
 	en.message(val.Elem())
-
-	if len(en.Bytes()) == 0 {
-		return nil, errors.New("struct has no serializable fields")
-	}
-
 	return en.Bytes(), nil
 }
 
@@ -74,14 +69,17 @@ func (en *encoder) message(sval reflect.Value) {
 		}
 	}()
 	// Encode all fields in-order
+	noPublicFields := true
 	for _, index = range ProtoFields(sval.Type()) {
 		field := sval.FieldByIndex(index.Index)
 		key := uint64(index.ID) << 3
-		//fmt.Printf("field %d: %s %v\n", 1+i,
-		//	sval.Type().Field(i).Name, field.CanSet())
 		if field.CanSet() { // Skip blank/padding fields
 			en.value(key, field, index.Prefix)
+			noPublicFields = false
 		}
+	}
+	if noPublicFields {
+		panic("struct has no serializable fields")
 	}
 }
 

--- a/encode.go
+++ b/encode.go
@@ -440,8 +440,7 @@ func (en *encoder) sliceReflect(key uint64, slval reflect.Value) {
 
 	case reflect.Float64:
 		for i := 0; i < sllen; i++ {
-			packed.u64(math.Float64bits(slval.Index(i).Float()
-                                 ))
+			packed.u64(math.Float64bits(slval.Index(i).Float()))
 		}
 
 	case reflect.Uint8: // Write the byte-slice as one key,value pair

--- a/encode.go
+++ b/encode.go
@@ -69,8 +69,12 @@ func (en *encoder) message(sval reflect.Value) {
 		}
 	}()
 	// Encode all fields in-order
+	protoFields := ProtoFields(sval.Type())
+	if len(protoFields) == 0 {
+		return
+	}
 	noPublicFields := true
-	for _, index = range ProtoFields(sval.Type()) {
+	for _, index = range protoFields {
 		field := sval.FieldByIndex(index.Index)
 		key := uint64(index.ID) << 3
 		if field.CanSet() { // Skip blank/padding fields
@@ -79,7 +83,7 @@ func (en *encoder) message(sval reflect.Value) {
 		}
 	}
 	if noPublicFields {
-		fmt.Println("struct has no serializable fields")
+		panic("struct has no serializable fields")
 	}
 }
 

--- a/encode.go
+++ b/encode.go
@@ -54,6 +54,11 @@ func Encode(structPtr interface{}) (bytes []byte, err error) {
 		return nil, errors.New("encode takes a pointer to struct")
 	}
 	en.message(val.Elem())
+
+	if len(en.Bytes()) == 0 {
+		return nil, errors.New("struct has no serializable fields")
+	}
+
 	return en.Bytes(), nil
 }
 

--- a/privateFields_test.go
+++ b/privateFields_test.go
@@ -13,16 +13,25 @@ type Public struct {
 	A int
 }
 
+type Empty struct {
+	Empty *string
+}
+
 func TestPrivate(t *testing.T) {
 	s := Private{37}
 	u := Public{37}
+	str := "b"
+	e := Empty{&str}
 
 	bufS, errS := Encode(&s)
 	bufU, errU := Encode(&u)
+	bufE, errE := Encode(&e)
 
 	t.Log(bufS, errS)
 	t.Log(bufU, errU)
+	t.Log(bufE, errE)
 
-	assert.Error(t, errS, "")
-	assert.NoError(t, errU, "")
+	assert.Error(t, errS)
+	assert.NoError(t, errU)
+	assert.NoError(t, errE)
 }

--- a/privateFields_test.go
+++ b/privateFields_test.go
@@ -1,0 +1,28 @@
+package protobuf
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+type Private struct {
+	a int
+}
+
+type Public struct {
+	A int
+}
+
+func TestPrivate(t *testing.T) {
+	s := Private{37}
+	u := Public{37}
+
+	bufS, errS := Encode(&s)
+	bufU, errU := Encode(&u)
+
+	t.Log(bufS, errS)
+	t.Log(bufU, errU)
+
+	assert.Error(t, errS, "")
+	assert.NoError(t, errU, "")
+}

--- a/privateFields_test.go
+++ b/privateFields_test.go
@@ -31,7 +31,7 @@ func TestPrivate(t *testing.T) {
 	t.Log(bufU, errU)
 	t.Log(bufE, errE)
 
-	assert.Error(t, errS)
-	assert.NoError(t, errU)
-	assert.NoError(t, errE)
+	assert.Equal(t, []byte(nil), bufS)
+	assert.Equal(t, []byte{0x8, 0x4a}, bufU)
+	assert.Equal(t, []byte{0xa, 0x1, 0x62}, bufE)
 }


### PR DESCRIPTION
I went with the simple solution of checking the length of `en.Bytes()` before returning it in Encode().
And that is because of the equivalence: 
"len(en.Bytes()) == 0" iff "struct has no serializable fields"

The alternative I can see us doing is:
in (en *encoder) message, if no field.CanSet() was true in the loop, we can do something. However, similarly to the issue #30 no other method than Encode can return errors.

Closes #38 