### PR TITLE
Fix map encoding

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -23,8 +23,8 @@ type Constructors map[reflect.Type]func() interface{}
 // String returns an easy way to visualize what you have in your constructors.
 func (c *Constructors) String() string {
 	var s string
-	for k, v := range *c {
-		s += k.String() + "=>" + fmt.Sprintf("%#v", v) + "\t"
+	for k := range *c {
+		s += k.String() + "=>" + "(func() interface {})" + "\t"
 	}
 	return s
 }
@@ -349,8 +349,6 @@ var ufixed64type = reflect.TypeOf(Ufixed64(0))
 
 // Handle decoding of slices
 func (de *decoder) slice(slval reflect.Value, vb []byte) error {
-
-
 	// Find the element type, and create a temporary instance of it.
 	eltype := slval.Type().Elem()
 	val := reflect.New(eltype).Elem()

--- a/encode.go
+++ b/encode.go
@@ -394,9 +394,8 @@ func (en *encoder) handleMap(key uint64, mpval reflect.Value, prefix TagPrefix) 
 		}
 
 		packed := encoder{}
-		packed.value(key, mkey, prefix)
-		fieldId := uint64(key >> 3)
-		packed.value(uint64(fieldId+1)<<3, mval, prefix)
+		packed.value(1<<3, mkey, prefix)
+		packed.value(2<<3, mval, prefix)
 
 		en.uvarint(key | 2)
 		b := packed.Bytes()

--- a/map_test.go
+++ b/map_test.go
@@ -109,6 +109,10 @@ func TestMapFieldRoundTrips(t *testing.T) {
 	}
 	for _, pair := range [][2]interface{}{
 		{m.NameMapping, m2.NameMapping},
+		{m.MsgMapping, m2.MsgMapping},
+		{m.ByteMapping, m2.ByteMapping},
+		{m.StrToStr, m2.StrToStr},
+		{m.StructMapping, m2.StructMapping},
 	} {
 		if !reflect.DeepEqual(pair[0], pair[1]) {
 			t.Errorf("Map did not survive a round trip.\ninitial: %v\n  final: %v", pair[0], pair[1])


### PR DESCRIPTION
The map encoding function should encode map entries like below, as described in the comments
```
 			message MapFieldEntry {
 				key_type key = 1;
 				value_type value = 2;
			}
```
but it doesn't currently do it and this PR fixes it.

Also fix missing tests for encoding maps.