### PR TITLE
Catch escaping panics

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -49,6 +49,11 @@ func Decode(buf []byte, structPtr interface{}) error {
 // DecodeWithConstructors is like Decode, but you can pass a map of
 // constructors with which to instantiate interface types.
 func DecodeWithConstructors(buf []byte, structPtr interface{}, cons Constructors) error {
+	defer func() {
+		if e := recover(); e != nil {
+			fmt.Println(e.(string))
+		}
+	}()
 	if structPtr == nil {
 		return nil
 	}
@@ -193,7 +198,14 @@ func (d *decoder) decodeSignedInt(wiretype int, v uint64) (int64, error) {
 }
 
 func (de *decoder) putvalue(wiretype int, val reflect.Value,
-	v uint64, vb []byte) error {
+	v uint64, vb []byte) (err error) {
+
+	// a panic might occur in cases reflect.Ptr or reflect.Interface
+	defer func() {
+		if e := recover(); e != nil {
+			err = errors.New(e.(string))
+		}
+	}()
 
 	// If val is not settable, it either represents an out-of-range field
 	// or an in-range but blank (padding) field in the struct.

--- a/decode.go
+++ b/decode.go
@@ -215,8 +215,8 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 		}
 		val.SetBool(v != 0)
 
-		// Signed integers may be encoded either zigzag-varint or fixed
-		// Note that protobufs don't support 8- or 16-bit ints.
+    // Signed integers may be encoded either zigzag-varint or fixed
+    // Note that protobufs don't support 8- or 16-bit ints.
 	case reflect.Int, reflect.Int32, reflect.Int64:
 		if val.Kind() == reflect.Int && val.Type().Size() < 8 {
 			return errors.New("detected a 32bit machine, please use either int64 or int32")
@@ -228,7 +228,7 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 		}
 		val.SetInt(sv)
 
-		// Varint-encoded 32-bit and 64-bit unsigned integers.
+	// Varint-encoded 32-bit and 64-bit unsigned integers.
 	case reflect.Uint, reflect.Uint32, reflect.Uint64:
 		if val.Kind() == reflect.Uint && val.Type().Size() < 8 {
 			return errors.New("detected a 32bit machine, please use either uint64 or uint32")
@@ -243,28 +243,28 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 			return errors.New("bad wiretype for uint")
 		}
 
-		// Fixed-length 32-bit floats.
+	// Fixed-length 32-bit floats.
 	case reflect.Float32:
 		if wiretype != 5 {
 			return errors.New("bad wiretype for float32")
 		}
 		val.SetFloat(float64(math.Float32frombits(uint32(v))))
 
-		// Fixed-length 64-bit floats.
+	// Fixed-length 64-bit floats.
 	case reflect.Float64:
 		if wiretype != 1 {
 			return errors.New("bad wiretype for float64")
 		}
 		val.SetFloat(math.Float64frombits(v))
 
-		// Length-delimited string.
+    // Length-delimited string.
 	case reflect.String:
 		if wiretype != 2 {
 			return errors.New("bad wiretype for string")
 		}
 		val.SetString(string(vb))
 
-		// Embedded message
+	// Embedded message
 	case reflect.Struct:
 		if val.Type() == timeType {
 			sv, err := de.decodeSignedInt(wiretype, v)
@@ -280,7 +280,7 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 		}
 		return de.message(vb, val)
 
-		// Optional field
+	// Optional field
 	case reflect.Ptr:
 		// Instantiate pointer's element type.
 		if val.IsNil() {
@@ -288,7 +288,7 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 		}
 		return de.putvalue(wiretype, val.Elem(), v, vb)
 
-		// Repeated field or byte-slice
+	// Repeated field or byte-slice
 	case reflect.Slice, reflect.Array:
 		if wiretype != 2 {
 			return errors.New("bad wiretype for repeated field")

--- a/decode.go
+++ b/decode.go
@@ -48,10 +48,10 @@ func Decode(buf []byte, structPtr interface{}) error {
 
 // DecodeWithConstructors is like Decode, but you can pass a map of
 // constructors with which to instantiate interface types.
-func DecodeWithConstructors(buf []byte, structPtr interface{}, cons Constructors) error {
+func DecodeWithConstructors(buf []byte, structPtr interface{}, cons Constructors) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
-			fmt.Println(e.(string))
+			err = errors.New(e.(string))
 		}
 	}()
 	if structPtr == nil {
@@ -198,15 +198,7 @@ func (d *decoder) decodeSignedInt(wiretype int, v uint64) (int64, error) {
 }
 
 func (de *decoder) putvalue(wiretype int, val reflect.Value,
-	v uint64, vb []byte) (err error) {
-
-	// a panic might occur in cases reflect.Ptr or reflect.Interface
-	defer func() {
-		if e := recover(); e != nil {
-			err = errors.New(e.(string))
-		}
-	}()
-
+	v uint64, vb []byte) error {
 	// If val is not settable, it either represents an out-of-range field
 	// or an in-range but blank (padding) field in the struct.
 	// In this case, simply ignore and discard the field's content.
@@ -223,8 +215,8 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 		}
 		val.SetBool(v != 0)
 
-	// Signed integers may be encoded either zigzag-varint or fixed
-	// Note that protobufs don't support 8- or 16-bit ints.
+		// Signed integers may be encoded either zigzag-varint or fixed
+		// Note that protobufs don't support 8- or 16-bit ints.
 	case reflect.Int, reflect.Int32, reflect.Int64:
 		if val.Kind() == reflect.Int && val.Type().Size() < 8 {
 			return errors.New("detected a 32bit machine, please use either int64 or int32")
@@ -236,7 +228,7 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 		}
 		val.SetInt(sv)
 
-	// Varint-encoded 32-bit and 64-bit unsigned integers.
+		// Varint-encoded 32-bit and 64-bit unsigned integers.
 	case reflect.Uint, reflect.Uint32, reflect.Uint64:
 		if val.Kind() == reflect.Uint && val.Type().Size() < 8 {
 			return errors.New("detected a 32bit machine, please use either uint64 or uint32")
@@ -251,28 +243,28 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 			return errors.New("bad wiretype for uint")
 		}
 
-	// Fixed-length 32-bit floats.
+		// Fixed-length 32-bit floats.
 	case reflect.Float32:
 		if wiretype != 5 {
 			return errors.New("bad wiretype for float32")
 		}
 		val.SetFloat(float64(math.Float32frombits(uint32(v))))
 
-	// Fixed-length 64-bit floats.
+		// Fixed-length 64-bit floats.
 	case reflect.Float64:
 		if wiretype != 1 {
 			return errors.New("bad wiretype for float64")
 		}
 		val.SetFloat(math.Float64frombits(v))
 
-	// Length-delimited string.
+		// Length-delimited string.
 	case reflect.String:
 		if wiretype != 2 {
 			return errors.New("bad wiretype for string")
 		}
 		val.SetString(string(vb))
 
-	// Embedded message
+		// Embedded message
 	case reflect.Struct:
 		if val.Type() == timeType {
 			sv, err := de.decodeSignedInt(wiretype, v)
@@ -288,7 +280,7 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 		}
 		return de.message(vb, val)
 
-	// Optional field
+		// Optional field
 	case reflect.Ptr:
 		// Instantiate pointer's element type.
 		if val.IsNil() {
@@ -296,7 +288,7 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 		}
 		return de.putvalue(wiretype, val.Elem(), v, vb)
 
-	// Repeated field or byte-slice
+		// Repeated field or byte-slice
 	case reflect.Slice, reflect.Array:
 		if wiretype != 2 {
 			return errors.New("bad wiretype for repeated field")

--- a/decode.go
+++ b/decode.go
@@ -215,9 +215,9 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 		}
 		val.SetBool(v != 0)
 
-    // Signed integers may be encoded either zigzag-varint or fixed
-    // Note that protobufs don't support 8- or 16-bit ints.
 	case reflect.Int, reflect.Int32, reflect.Int64:
+		// Signed integers may be encoded either zigzag-varint or fixed
+		// Note that protobufs don't support 8- or 16-bit ints.
 		if val.Kind() == reflect.Int && val.Type().Size() < 8 {
 			return errors.New("detected a 32bit machine, please use either int64 or int32")
 		}
@@ -228,8 +228,8 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 		}
 		val.SetInt(sv)
 
-	// Varint-encoded 32-bit and 64-bit unsigned integers.
 	case reflect.Uint, reflect.Uint32, reflect.Uint64:
+		// Varint-encoded 32-bit and 64-bit unsigned integers.
 		if val.Kind() == reflect.Uint && val.Type().Size() < 8 {
 			return errors.New("detected a 32bit machine, please use either uint64 or uint32")
 		}
@@ -243,29 +243,29 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 			return errors.New("bad wiretype for uint")
 		}
 
-	// Fixed-length 32-bit floats.
 	case reflect.Float32:
+		// Fixed-length 32-bit floats.
 		if wiretype != 5 {
 			return errors.New("bad wiretype for float32")
 		}
 		val.SetFloat(float64(math.Float32frombits(uint32(v))))
 
-	// Fixed-length 64-bit floats.
 	case reflect.Float64:
+		// Fixed-length 64-bit floats.
 		if wiretype != 1 {
 			return errors.New("bad wiretype for float64")
 		}
 		val.SetFloat(math.Float64frombits(v))
 
-    // Length-delimited string.
 	case reflect.String:
+		// Length-delimited string.
 		if wiretype != 2 {
 			return errors.New("bad wiretype for string")
 		}
 		val.SetString(string(vb))
 
-	// Embedded message
 	case reflect.Struct:
+		// Embedded message
 		if val.Type() == timeType {
 			sv, err := de.decodeSignedInt(wiretype, v)
 			if err != nil {
@@ -280,16 +280,16 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 		}
 		return de.message(vb, val)
 
-	// Optional field
 	case reflect.Ptr:
+		// Optional field
 		// Instantiate pointer's element type.
 		if val.IsNil() {
 			val.Set(de.instantiate(val.Type().Elem()))
 		}
 		return de.putvalue(wiretype, val.Elem(), v, vb)
 
-	// Repeated field or byte-slice
 	case reflect.Slice, reflect.Array:
+		// Repeated field or byte-slice
 		if wiretype != 2 {
 			return errors.New("bad wiretype for repeated field")
 		}

--- a/encode.go
+++ b/encode.go
@@ -72,8 +72,8 @@ func (en *encoder) message(sval reflect.Value) {
 	for _, index = range ProtoFields(sval.Type()) {
 		field := sval.FieldByIndex(index.Index)
 		key := uint64(index.ID) << 3
-		//fmt.Printf("field %d: %s %v\n", 1+i,
-		//	sval.Type().Field(i).Name, field.CanSet())
+		// fmt.Printf("field %d: %s %v\n", 1+i,
+		// 	sval.Type().Field(i).Name, field.CanSet())
 		if field.CanSet() { // Skip blank/padding fields
 			en.value(key, field, index.Prefix)
 		}
@@ -177,36 +177,36 @@ func (en *encoder) value(key uint64, val reflect.Value, prefix TagPrefix) {
 		}
 		en.uvarint(v)
 
-	// Varint-encoded 32-bit and 64-bit signed integers.
-	// Note that protobufs don't support 8- or 16-bit ints.
 	case reflect.Int, reflect.Int32, reflect.Int64:
+		// Varint-encoded 32-bit and 64-bit signed integers.
+		// Note that protobufs don't support 8- or 16-bit ints.
 		en.uvarint(key | 0)
 		en.svarint(val.Int())
 
-	// Varint-encoded 32-bit and 64-bit unsigned integers.
 	case reflect.Uint32, reflect.Uint64:
+		// Varint-encoded 32-bit and 64-bit unsigned integers.
 		en.uvarint(key | 0)
 		en.uvarint(val.Uint())
 
-	// Fixed-length 32-bit floats.
 	case reflect.Float32:
+		// Fixed-length 32-bit floats.
 		en.uvarint(key | 5)
 		en.u32(math.Float32bits(float32(val.Float())))
 
-	// Fixed-length 64-bit floats.
 	case reflect.Float64:
+		// Fixed-length 64-bit floats.
 		en.uvarint(key | 1)
 		en.u64(math.Float64bits(val.Float()))
 
-	// Length-delimited string.
 	case reflect.String:
+		// Length-delimited string.
 		en.uvarint(key | 2)
 		b := []byte(val.String())
 		en.uvarint(uint64(len(b)))
 		en.Write(b)
 
-	// Embedded messages.
-	case reflect.Struct: // embedded message
+	case reflect.Struct:
+		// Embedded messages.
 		en.uvarint(key | 2)
 		emb := encoder{}
 		emb.message(val)
@@ -214,13 +214,13 @@ func (en *encoder) value(key uint64, val reflect.Value, prefix TagPrefix) {
 		en.uvarint(uint64(len(b)))
 		en.Write(b)
 
-	// Length-delimited slices  or byte-vectors.
 	case reflect.Slice, reflect.Array:
+		// Length-delimited slices  or byte-vectors.
 		en.slice(key, val)
 		return
 
-	// Optional field: encode only if pointer is non-nil.
 	case reflect.Ptr:
+		// Optional field: encode only if pointer is non-nil.
 		if val.IsNil() {
 			if prefix == TagRequired {
 				panic("required field is nil")
@@ -229,8 +229,8 @@ func (en *encoder) value(key uint64, val reflect.Value, prefix TagPrefix) {
 		}
 		en.value(key, val.Elem(), prefix)
 
-	// Abstract interface field.
 	case reflect.Interface:
+		// Abstract interface field.
 		if val.IsNil() {
 			return
 		}

--- a/encode.go
+++ b/encode.go
@@ -228,7 +228,6 @@ func (en *encoder) value(key uint64, val reflect.Value, prefix TagPrefix) {
 
 	// Length-delimited slices  or byte-vectors.
 	case reflect.Slice, reflect.Array:
-
 		en.slice(key, val)
 		return
 
@@ -354,7 +353,6 @@ func (en *encoder) slice(key uint64, slval reflect.Value) {
 		}
 		return
 	default: // We'll need to use the reflective path
-
 		en.sliceReflect(key, slval)
 		return
 	}
@@ -461,7 +459,6 @@ func (en *encoder) sliceReflect(key uint64, slval reflect.Value) {
 		return
 
 	default: // Write each element as a separate key,value pair
-
 		t := slval.Type().Elem()
 		if t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
 			subSlice := t.Elem()


### PR DESCRIPTION
Closes #46 

The two panics in decode.go can be occured by putvalue and instantiate. Just pushed a fix that catches the panics thrown by instantiate in putvalue. And I saw that all panics thrown by putvalue are directly being caught like in:

```
         if err := de.putvalue(wiretype, val, v, vb); err != nil {
		return nil, err
	}
```
I also tried catching the panic in GenerateProtobufDefinition but am not sure if what I did is indeed correct.