### PR TITLE
Marshalize structs

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -52,6 +52,9 @@ func DecodeWithConstructors(buf []byte, structPtr interface{}, cons Constructors
 	if structPtr == nil {
 		return nil
 	}
+	if isBinaryUnmarsheler(structPtr) {
+		return structPtr.(encoding.BinaryUnmarshaler).UnmarshalBinary(buf)
+	}
 	de := decoder{cons}
 	val := reflect.ValueOf(structPtr)
 	// if its NOT a pointer, it is bad return an error
@@ -458,4 +461,9 @@ func (de *decoder) mapEntry(slval reflect.Value, vb []byte) error {
 	slval.SetMapIndex(k, v)
 
 	return nil
+}
+
+func isBinaryUnmarsheler(x interface{}) bool {
+	y := reflect.TypeOf((*encoding.BinaryUnmarshaler)(nil)).Elem()
+	return reflect.PtrTo(reflect.TypeOf(x)).Implements(y)
 }

--- a/encode.go
+++ b/encode.go
@@ -228,7 +228,6 @@ func (en *encoder) value(key uint64, val reflect.Value, prefix TagPrefix) {
 
 	// Length-delimited slices  or byte-vectors.
 	case reflect.Slice, reflect.Array:
-
 		en.slice(key, val)
 		return
 
@@ -354,7 +353,6 @@ func (en *encoder) slice(key uint64, slval reflect.Value) {
 		}
 		return
 	default: // We'll need to use the reflective path
-
 		en.sliceReflect(key, slval)
 		return
 	}
@@ -461,7 +459,6 @@ func (en *encoder) sliceReflect(key uint64, slval reflect.Value) {
 		return
 
 	default: // Write each element as a separate key,value pair
-
 		t := slval.Type().Elem()
 		if t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
 			subSlice := t.Elem()

--- a/encode.go
+++ b/encode.go
@@ -48,6 +48,9 @@ func Encode(structPtr interface{}) (bytes []byte, err error) {
 	if structPtr == nil {
 		return nil, nil
 	}
+	if isBinaryMarshaler(structPtr) {
+		return structPtr.(encoding.BinaryMarshaler).MarshalBinary()
+	}
 	en := encoder{}
 	val := reflect.ValueOf(structPtr)
 	if val.Kind() != reflect.Ptr {
@@ -501,4 +504,9 @@ func (en *encoder) u64(v uint64) {
 	b[6] = byte(v >> 48)
 	b[7] = byte(v >> 56)
 	en.Write(b[:])
+}
+
+func isBinaryMarshaler (x interface{}) bool {
+	y := reflect.TypeOf((*encoding.BinaryMarshaler)(nil)).Elem()
+	return reflect.PtrTo(reflect.TypeOf(x)).Implements(y)
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,0 +1,54 @@
+package protobuf
+
+import (
+	"testing"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+)
+
+type ValueInt interface{
+	Print()string
+}
+
+type A struct{
+	Value int
+}
+
+func (a *A)MarshalBinary()([]byte, error){
+	return []byte(fmt.Sprintf("%d", a.Value)), nil
+}
+
+func (a *A)Print()string{
+	return ""
+}
+
+type B struct{
+	AValue A
+	AInt int
+}
+
+func TestMarshal(t *testing.T) {
+	var a A = A{0}
+	var b B = B{a, 1}
+
+	assert.True(t, isBinaryMarshaler(a))
+	assert.False(t, isBinaryMarshaler(b))
+
+	bufA, _ := Encode(&a)
+	bufB, _ := Encode(&b)
+
+	t.Log(bufA)
+	t.Log(bufB)
+
+	testA := A{}
+	testB := B{}
+
+	assert.True(t, isBinaryMarshaler(testA))
+	assert.False(t, isBinaryMarshaler(testB))
+
+	Decode(bufA, &testA)
+	Decode(bufB, &testB)
+
+	assert.Equal(t, testA, a)
+	assert.Equal(t, testB, b)
+}


### PR DESCRIPTION
Closes #5 

Added two methods, one in encode and one in decode to check if a struct implements the interfaces BinaryMarshaler and BinaryUnmarshaler.

Inside the encoding and decoding methods, apply the function to the structs that implement it.