### PR TITLE
Fix BinaryMarshaller support and include an example of big.Int marshaling

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -57,9 +57,11 @@ func DecodeWithConstructors(buf []byte, structPtr interface{}, cons Constructors
 	if structPtr == nil {
 		return nil
 	}
-	if isBinaryUnmarsheler(structPtr) {
-		return structPtr.(encoding.BinaryUnmarshaler).UnmarshalBinary(buf)
+
+	if bu, ok := structPtr.(encoding.BinaryUnmarshaler); ok {
+		return bu.UnmarshalBinary(buf)
 	}
+
 	de := decoder{cons}
 	val := reflect.ValueOf(structPtr)
 	// if its NOT a pointer, it is bad return an error
@@ -471,9 +473,4 @@ func (de *decoder) mapEntry(slval reflect.Value, vb []byte) error {
 	slval.SetMapIndex(k, v)
 
 	return nil
-}
-
-func isBinaryUnmarsheler(x interface{}) bool {
-	y := reflect.TypeOf((*encoding.BinaryUnmarshaler)(nil)).Elem()
-	return reflect.PtrTo(reflect.TypeOf(x)).Implements(y)
 }

--- a/encode.go
+++ b/encode.go
@@ -48,9 +48,11 @@ func Encode(structPtr interface{}) (bytes []byte, err error) {
 	if structPtr == nil {
 		return nil, nil
 	}
-	if isBinaryMarshaler(structPtr) {
-		return structPtr.(encoding.BinaryMarshaler).MarshalBinary()
+
+	if bu, ok := structPtr.(encoding.BinaryMarshaler); ok {
+		return bu.MarshalBinary()
 	}
+
 	en := encoder{}
 	val := reflect.ValueOf(structPtr)
 	if val.Kind() != reflect.Ptr {
@@ -511,9 +513,4 @@ func (en *encoder) u64(v uint64) {
 	b[6] = byte(v >> 48)
 	b[7] = byte(v >> 56)
 	en.Write(b[:])
-}
-
-func isBinaryMarshaler (x interface{}) bool {
-	y := reflect.TypeOf((*encoding.BinaryMarshaler)(nil)).Elem()
-	return reflect.PtrTo(reflect.TypeOf(x)).Implements(y)
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,38 +1,36 @@
 package protobuf
 
 import (
-	"testing"
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
 
-type ValueInt interface{
-	Print()string
+type ValueInt interface {
+	Print() string
 }
 
-type A struct{
+type A struct {
 	Value int
 }
 
-func (a *A)MarshalBinary()([]byte, error){
+func (a *A) MarshalBinary() ([]byte, error) {
 	return []byte(fmt.Sprintf("%d", a.Value)), nil
 }
 
-func (a *A)Print()string{
+func (a *A) Print() string {
 	return ""
 }
 
-type B struct{
+type B struct {
 	AValue A
-	AInt int
+	AInt   int
 }
 
 func TestMarshal(t *testing.T) {
 	var a A = A{0}
 	var b B = B{a, 1}
-
-	assert.True(t, isBinaryMarshaler(a))
-	assert.False(t, isBinaryMarshaler(b))
 
 	bufA, _ := Encode(&a)
 	bufB, _ := Encode(&b)
@@ -42,9 +40,6 @@ func TestMarshal(t *testing.T) {
 
 	testA := A{}
 	testB := B{}
-
-	assert.True(t, isBinaryMarshaler(testA))
-	assert.False(t, isBinaryMarshaler(testB))
 
 	Decode(bufA, &testA)
 	Decode(bufB, &testB)


### PR DESCRIPTION
Fixes #54.