### PR TITLE
Correctly encode map[[X]byte]TYPE

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -1,10 +1,10 @@
 package protobuf
 
 import (
-	"fmt"
-	"testing"
-	"reflect"
 	"encoding/hex"
+	"reflect"
+	"testing"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,15 +20,11 @@ type ArrayTest2 struct {
 	A []int32
 }
 
-type ArrayTest3 struct{
+type ArrayTest3 struct {
 	A int
 }
 
-
-func TestArray(t *testing.T){
-
-	fmt.Println("TestArray:")
-
+func TestArray(t *testing.T) {
 	// largest int32 is 2147483647
 	var large int = 3147483647
 
@@ -46,7 +42,6 @@ func TestArray(t *testing.T){
 	t.Log(hex.Dump(buf1))
 	t.Log(hex.Dump(buf2))
 	t.Log(hex.Dump(buf3))
-
 
 	b0 := ArrayTest0{}
 	b1 := ArrayTest1{}

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -196,3 +196,28 @@ func TestBigInt(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "238756834756284658865287462349857298752354", v2.Int.String())
 }
+
+func TestArrayKey(t *testing.T) {
+	type typ struct {
+		M map[[4]byte]bool
+	}
+	t0 := &typ{M: make(map[[4]byte]bool)}
+
+	var k1 [4]byte
+	k2 := [4]byte{0, 1, 2, 3}
+	k3 := [4]byte{5, 6, 7, 8}
+
+	t0.M[k1] = true
+	t0.M[k2] = true
+
+	buf, err := Encode(t0)
+	assert.NoError(t, err)
+	assert.Equal(t, 20, len(buf))
+
+	var t1 typ
+	err = Decode(buf, &t1)
+	assert.NoError(t, err)
+	assert.True(t, t1.M[k1])
+	assert.True(t, t1.M[k2])
+	assert.False(t, t1.M[k3])
+}


### PR DESCRIPTION
Previously, using a fixed size array as the key to a map would
give an error because the key was not addressable. With this change,
the new code in the test case now works as expected.