### PR TITLE
Test unsuccessful interface decoding

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -50,8 +50,15 @@ func Decode(buf []byte, structPtr interface{}) error {
 // constructors with which to instantiate interface types.
 func DecodeWithConstructors(buf []byte, structPtr interface{}, cons Constructors) (err error) {
 	defer func() {
-		if e := recover(); e != nil {
-			err = e.(error)
+		if r := recover(); r != nil {
+			switch e := r.(type) {
+			case string:
+				err = errors.New(e)
+			case error:
+				err = e
+			default:
+				err = errors.New("Failed to decode the field")
+			}
 		}
 	}()
 	if structPtr == nil {

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -2,6 +2,7 @@ package protobuf
 
 import (
 	"encoding"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -250,4 +251,63 @@ func TestInterface(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, pp.P1.String(), dpp.P1.String())
 	require.Equal(t, pp.P2.String(), dpp.P2.String())
+}
+
+type dummyInterface interface {
+	String() string
+	encoding.BinaryUnmarshaler
+	InterfaceMarshaler
+}
+
+type dummyStruct struct{}
+
+func (ds *dummyStruct) String() string {
+	return "dummy"
+}
+
+func (ds *dummyStruct) MarshalBinary() ([]byte, error) {
+	return []byte{1, 2, 3}, nil
+}
+
+func (ds *dummyStruct) UnmarshalBinary(data []byte) error {
+	return nil
+}
+
+func (ds *dummyStruct) MarshalID() [8]byte {
+	return [8]byte{'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a'}
+}
+
+type dummyWrapper struct {
+	D dummyInterface
+}
+
+// TestInterface_UnknownType checks that proper errors are returned in
+// the worst case scenario
+func TestInterface_UnknownType(t *testing.T) {
+	w := &dummyWrapper{D: &dummyStruct{}}
+	buf, err := Encode(w)
+
+	// encoding doesn't fail because it's the default constructor case
+	require.NoError(t, err)
+	require.NotNil(t, buf)
+	require.Equal(t, "0a03010203", fmt.Sprintf("%x", buf))
+
+	var r dummyWrapper
+	err = Decode(buf, &r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no constructor")
+
+	// this time there is a tag at encoding time
+	RegisterInterface(func() interface{} { return &dummyStruct{} })
+	buf, err = Encode(w)
+	require.NoError(t, err)
+	require.NotNil(t, buf)
+	require.Equal(t, "0a0b6161616161616161010203", fmt.Sprintf("%x", buf))
+
+	// but not at decoding time
+	generators = newInterfaceRegistry()
+
+	err = Decode(buf, &r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no constructor")
 }


### PR DESCRIPTION
This adds a test that will check an proper error is returned if no constructor or tag is found when decoding an interface. It also fixes a panic during recovering because of type checking.