### PR TITLE
(Un)Marshaling structs with internal Binary(Un)Marshaler support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 protobuf-fuzz.zip
 workdir
+vendor

--- a/decode.go
+++ b/decode.go
@@ -292,6 +292,8 @@ func (de *decoder) putvalue(wiretype int, val reflect.Value,
 			t := time.Unix(sv/int64(time.Second), sv%int64(time.Second))
 			val.Set(reflect.ValueOf(t))
 			return nil
+		} else if enc, ok := val.Addr().Interface().(encoding.BinaryUnmarshaler); ok {
+			return enc.UnmarshalBinary(vb[:])
 		}
 		if wiretype != 2 {
 			return errors.New("bad wiretype for embedded message")

--- a/encode.go
+++ b/encode.go
@@ -218,13 +218,25 @@ func (en *encoder) value(key uint64, val reflect.Value, prefix TagPrefix) {
 		en.Write(b)
 
 	case reflect.Struct:
-		// Embedded messages.
-		en.uvarint(key | 2)
-		emb := encoder{}
-		emb.message(val)
-		b := emb.Bytes()
-		en.uvarint(uint64(len(b)))
-		en.Write(b)
+		if enc, ok := val.Interface().(encoding.BinaryMarshaler); ok {
+			en.uvarint(key | 2)
+			b, err := enc.MarshalBinary()
+			if err != nil {
+				panic(err.Error())
+			}
+
+			en.uvarint(uint64(len(b)))
+			en.Write(b)
+
+		} else {
+			// Embedded messages.
+			en.uvarint(key | 2)
+			emb := encoder{}
+			emb.message(val)
+			b := emb.Bytes()
+			en.uvarint(uint64(len(b)))
+			en.Write(b)
+		}
 
 	case reflect.Slice, reflect.Array:
 		// Length-delimited slices or byte-vectors.

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -320,3 +320,39 @@ func TestInterface_UnknownType(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no constructor")
 }
+
+type Cid struct{ str string }
+
+type Block struct {
+	Cid Cid
+	A   int
+}
+
+func (c Cid) MarshalBinary() ([]byte, error) {
+	return []byte(c.str), nil
+}
+
+func (c *Cid) UnmarshalBinary(data []byte) error {
+	c.str = string(data)
+	return nil
+}
+
+func TestBinaryMarshalerStruct(t *testing.T) {
+	c1 := Cid{"1234"}
+	buf, err := Encode(&c1)
+	assert.Nil(t, err)
+
+	c2 := Cid{}
+	err = Decode(buf, &c2)
+	assert.Nil(t, err)
+	assert.Equal(t, c1, c2)
+
+	b1 := Block{Cid: Cid{"1234"}, A: 4}
+	buf, err = Encode(&b1)
+	assert.Nil(t, err)
+
+	b2 := Block{}
+	err = Decode(buf, &b2)
+	assert.Nil(t, err)
+	assert.Equal(t, b1, b2)
+}


### PR DESCRIPTION
In this patch structs that implemented Marshal/UnmarshalBinray Methods can be encoded/decoded correctly even it's added as a filed.
A good example is using [cid](https://github.com/multiformats/cid) for referring a doc inside a block.