### PR TITLE
Fix decoding of slices

### DIFF
--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -163,7 +163,34 @@ func TestProtobuf(t *testing.T) {
 	t2 := test{}
 	err = Decode(buf, &t2)
 	assert.NoError(t, err)
-	assert.Equal(t, t2, t1)
+	assert.Equal(t, t1, t2)
+}
+
+type simpleFilledInput struct {
+	AA []mybytes
+	I  string
+	BB []mybytes
+}
+
+func TestProtobuf_FilledInput(t *testing.T) {
+
+	t1 := simpleFilledInput{
+		[]mybytes{[]byte("the"), []byte("quick"), []byte("brown"), []byte("fox")},
+		"intermediate value",
+		[]mybytes{[]byte("the"), []byte("quick"), []byte("brown"), []byte("fox")},
+	}
+	buf, err := Encode(&t1)
+	assert.NoError(t, err)
+
+	t2 := simpleFilledInput{
+		[]mybytes{[]byte("the"), []byte("quick"), []byte("brown"), []byte("fox")},
+		"intermediate value",
+		[]mybytes{[]byte("the"), []byte("quick"), []byte("brown"), []byte("fox")},
+	}
+	err = Decode(buf, &t2)
+	assert.NoError(t, err)
+
+	assert.Equal(t, t1, t2)
 }
 
 type padded struct {

--- a/protobuf_test.go
+++ b/protobuf_test.go
@@ -167,17 +167,19 @@ func TestProtobuf(t *testing.T) {
 }
 
 type simpleFilledInput struct {
-	AA []mybytes
-	I  string
-	BB []mybytes
+	Bytes []mybytes
+	I     string
+	Ptr   *mybool
 }
 
 func TestProtobuf_FilledInput(t *testing.T) {
+	b0 := mybool(true)
+	b1 := mybool(false)
 
 	t1 := simpleFilledInput{
 		[]mybytes{[]byte("the"), []byte("quick"), []byte("brown"), []byte("fox")},
 		"intermediate value",
-		[]mybytes{[]byte("the"), []byte("quick"), []byte("brown"), []byte("fox")},
+		&b0,
 	}
 	buf, err := Encode(&t1)
 	assert.NoError(t, err)
@@ -185,11 +187,17 @@ func TestProtobuf_FilledInput(t *testing.T) {
 	t2 := simpleFilledInput{
 		[]mybytes{[]byte("the"), []byte("quick"), []byte("brown"), []byte("fox")},
 		"intermediate value",
-		[]mybytes{[]byte("the"), []byte("quick"), []byte("brown"), []byte("fox")},
+		&b1,
 	}
 	err = Decode(buf, &t2)
 	assert.NoError(t, err)
+	assert.Equal(t, t1, t2)
 
+	t1 = simpleFilledInput{}
+	buf, err = Encode(&t1)
+
+	err = Decode(buf, &t2)
+	assert.NoError(t, err)
 	assert.Equal(t, t1, t2)
 }
 


### PR DESCRIPTION
Without this fix, it could happen that a structure with an already
filled slice will keep the values alongside with the decoded ones.