### PR TITLE
Fix panic in encode recovering

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -41,7 +41,7 @@ type encoder struct {
 func Encode(structPtr interface{}) (bytes []byte, err error) {
 	defer func() {
 		if e := recover(); e != nil {
-			err = errors.New(e.(string))
+			err = fmt.Errorf("%v", e)
 			bytes = nil
 		}
 	}()


### PR DESCRIPTION
This fixes the panic that was happening when the recover had an
error type different than a string.